### PR TITLE
Update embed.mdx

### DIFF
--- a/guides/web-checkout/embed.mdx
+++ b/guides/web-checkout/embed.mdx
@@ -89,8 +89,8 @@ token you generated in the previous step.
   <TabItem value="react">
 
 ```js
-const Gr4vyEmbed = require(`@gr4vy/embed-react`)
-// or: import Gr4vyEmbed from (`@gr4vy/embed-react)
+import Gr4vyEmbed from (`@gr4vy/embed-react)
+// or: const { default: Gr4vyEmbed } = require(`@gr4vy/embed-react`)
 
 <Gr4vyEmbed
   gr4vyId='acme'
@@ -111,8 +111,8 @@ const Gr4vyEmbed = require(`@gr4vy/embed-react`)
 </form>
 
 <script>
-  const { setup } = require(`@gr4vy/embed`);
-  // or: import { setup } from (`@gr4vy/embed`)
+  import { setup } from (`@gr4vy/embed`)
+  // or: const { setup } = require(`@gr4vy/embed`);
 
   setup({
     gr4vyId: "acme",
@@ -143,8 +143,8 @@ element using any [`querySelector`][queryselector]-compatible query.
 </form>
 
 <script>
-  const { setup } = require(`@gr4vy/embed`);
-  // or: import { setup } from (`@gr4vy/embed`)
+  import { setup } from (`@gr4vy/embed`);
+  // or: const { setup } = require(`@gr4vy/embed`);
 
   setup({
     gr4vyId: "acme",
@@ -225,8 +225,8 @@ const Gr4vyEmbed = require(`@gr4vy/embed-react`)
 </form>
 
 <script>
-  const { setup } = require(`@gr4vy/embed`);
-  // or: import { setup } from (`@gr4vy/embed`)
+  import { setup } from (`@gr4vy/embed`);
+  // or: const { setup } = require(`@gr4vy/embed`);
 
   setup({
     gr4vyId: "acme",
@@ -256,8 +256,8 @@ const Gr4vyEmbed = require(`@gr4vy/embed-react`)
 </form>
 
 <script>
-  const { setup } = require(`@gr4vy/embed`);
-  // or: import { setup } from (`@gr4vy/embed`)
+  import { setup } from (`@gr4vy/embed`)
+  // or: const { setup } = require(`@gr4vy/embed`);
 
   setup({
     gr4vyId: "acme",


### PR DESCRIPTION
Moved ES module syntax to the top, CJS to alternative, updated default export example for embed-react.

I have also created a separate ticket to update the `@gr4vy/embed-react` package. (This will not affect the correctness of the docs).
https://sprints.zoho.com/team/gr4vy#itemdetails/P4/I79